### PR TITLE
patch for getting key action PRESS/RELEASE from darnitKeyboardRawPop

### DIFF
--- a/include/darnit/darnit_input.h
+++ b/include/darnit/darnit_input.h
@@ -4,6 +4,9 @@
 #define		BUTTON_ACCEPT		b
 #define		BUTTON_CANCEL		a
 
+#define DARNIT_KEYACTION_PRESS		1
+#define DARNIT_KEYACTION_RELEASE	2
+
 
 typedef struct {
 	unsigned int	left	: 1;
@@ -47,8 +50,6 @@ typedef struct {
 	unsigned int			r;
 } DARNIT_INPUT_MAP;
 
-
-
 DARNIT_KEYS darnitButtonGet();
 void darnitButtonSet(DARNIT_KEYS buttons);
 DARNIT_KEYS darnitButtonZero();
@@ -59,8 +60,8 @@ void darnitButtonMappingReset();
 void darnitButtonMappingSet(DARNIT_INPUT_MAP map);
 DARNIT_INPUT_MAP darnitButtonMappingGet();
 void darnitJoystickGet(int *js0_x, int *js0_y, int *js1_x, int *js1_y);
-void darnitKeyboardRawPush(int sym);
-int darnitKeyboardRawPop();
+void darnitKeyboardRawPush(int sym, int action);
+int darnitKeyboardRawPop(int *action);
 void darnitKeyboardRawClear();
 
 #endif

--- a/src/api/darnit_input.c
+++ b/src/api/darnit_input.c
@@ -70,15 +70,15 @@ void EXPORT_THIS darnitJoystickGet(int *js0_x, int *js0_y, int *js1_x, int *js1_
 }
 
 
-void EXPORT_THIS darnitKeyboardRawPush(int sym) {
-	inputRawPush(sym);
+void EXPORT_THIS darnitKeyboardRawPush(int sym, int action) {
+	inputRawPush(sym, action);
 
 	return;
 }
 
 
-int EXPORT_THIS darnitKeyboardRawPop() {
-	return inputRawPop();
+int EXPORT_THIS darnitKeyboardRawPop(int *action) {
+	return inputRawPop(action);
 }
 
 

--- a/src/input.c
+++ b/src/input.c
@@ -3,20 +3,23 @@
 void darnitQuit();
 
 
-void inputRawPush(int sym) {
+void inputRawPush(int sym, int action) {
 	if (d->input.raw.use == RAW_BUFFER_LEN)
 		return;
 	d->input.raw.raw[d->input.raw.use] = sym;
+	d->input.raw.action[d->input.raw.use] = action;
 	d->input.raw.use++;
 
 	return;
 }
 
 
-int inputRawPop() {
+int inputRawPop(int *action) {
 	if (d->input.raw.use == 0)
 		return 0;
 	d->input.raw.use--;
+	if(action)
+		*action=d->input.raw.action[d->input.raw.use];
 
 	return d->input.raw.raw[d->input.raw.use];
 }
@@ -127,7 +130,7 @@ void inputPoll() {
 				d->input.upper |= 1;
 			if (d->input.event.key.keysym.sym < 0x80)	/* ASCII */
 				d->input.lastkey = d->input.event.key.keysym.sym;
-			inputRawPush(d->input.event.key.keysym.sym);
+			inputRawPush(d->input.event.key.keysym.sym, DARNIT_KEYACTION_PRESS);
 
 		} else if (d->input.event.type == SDL_KEYUP) {
 			if (d->input.event.key.keysym.sym == d->input.map.up) {
@@ -175,6 +178,8 @@ void inputPoll() {
 				d->input.upper |= 1;
 				d->input.upper ^= 1;
 			}
+			inputRawPush(d->input.event.key.keysym.sym, DARNIT_KEYACTION_RELEASE);
+			
 		} else if (d->input.event.type == SDL_MOUSEMOTION) {
 			d->input.mouse.x = d->input.event.motion.x;
 			d->input.mouse.y = d->input.event.motion.y;

--- a/src/input.h
+++ b/src/input.h
@@ -21,6 +21,9 @@
 #define		BUTTON_ACCEPT		KEY_B
 #define		BUTTON_CANCEL		KEY_A
 
+#define DARNIT_KEYACTION_PRESS		1
+#define DARNIT_KEYACTION_RELEASE	2
+
 #define		RAW_BUFFER_LEN		8
 
 typedef struct {
@@ -53,6 +56,7 @@ typedef struct {
 
 typedef struct {
 	int				raw[RAW_BUFFER_LEN];
+	int				action[RAW_BUFFER_LEN];
 	unsigned int			use;
 } INPUT_RAW;
 
@@ -70,8 +74,8 @@ typedef struct {
 } INPUT_STRUCT;
 
 
-void inputRawPush(int sym);
-int inputRawPop();
+void inputRawPush(int sym, int action);
+int inputRawPop(int *action);
 void inputPoll();
 int inputInit();
 unsigned int inputASCIIPop();


### PR DESCRIPTION
needed for ui to actually make use of the darnitKeyboardRawPop function in the event handling

int darnitKeyboardRawPop(int *action);

key action stored in value pointed to by 'action', can be one of
DARNIT_KEYACTION_PRESS
DARNIT_KEYACTION_RELEASE

also updated darnitKeyboardRawPush:
void darnitKeyboardRawPush(int sym, int action);

actions added as member
int             action[RAW_BUFFER_LEN];
in struct INPUT_RAW
