### PR TITLE
Fixed crash when exiting on windows with libdarnit compiled using O3 flag

### DIFF
--- a/darnit/api/darnit_main.c
+++ b/darnit/api/darnit_main.c
@@ -194,7 +194,7 @@ DARNIT_PLATFORM EXPORT_THIS d_platform_get() {
 void EXPORT_THIS d_quit() {
 	videoDestroy();
 
-	exit(0);
+	SDL_Quit();
 
 	return;
 }


### PR DESCRIPTION
Fixed crash when exiting on windows with libdarnit compiled using O3 flag
